### PR TITLE
Feat/cmake fixes

### DIFF
--- a/src/common/domain/CMakeLists.txt
+++ b/src/common/domain/CMakeLists.txt
@@ -6,3 +6,4 @@ add_subdirectory(core_datastructures)
 
 
 ament_package()
+

--- a/src/common/domain/core_datastructures/CMakeLists.txt
+++ b/src/common/domain/core_datastructures/CMakeLists.txt
@@ -1,10 +1,19 @@
 cmake_minimum_required(VERSION 3.5)
-project(lib_core_datastructures)
-message("CMAKE_CURRENT_SOURCE_DIR = ${CMAKE_CURRENT_SOURCE_DIR}")
+project(core_datastructures)
 
 file(GLOB core_datastructures_cpp_files "*.cpp")
+file(GLOB core_datastructures_hpp_files "*.hpp")
 
 add_library(${PROJECT_NAME} ${core_datastructures_cpp_files})
 
-target_link_libraries(${PROJECT_NAME} common_domain)
-# target_include_directories(lib_core_datastructures PUBLIC "${CMAKE_CURRENT_SOURCE_DIR}/../")
+install(
+  FILES ${core_datastructures_hpp_files} 
+  DESTINATION include/${PROJECT_NAME}
+  )
+
+install(
+  TARGETS ${PROJECT_NAME}
+  DESTINATION lib/${PROJECT_NAME}
+  )
+    
+target_include_directories(${PROJECT_NAME} PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/../)

--- a/src/common/domain/core_datastructures/CMakeLists.txt
+++ b/src/common/domain/core_datastructures/CMakeLists.txt
@@ -1,19 +1,17 @@
 cmake_minimum_required(VERSION 3.5)
 project(core_datastructures)
 
-file(GLOB core_datastructures_cpp_files "*.cpp")
-file(GLOB core_datastructures_hpp_files "*.hpp")
+file(GLOB cpp_files "*.cpp")
+file(GLOB hpp_files "*.hpp")
 
-add_library(${PROJECT_NAME} ${core_datastructures_cpp_files})
+add_library(${PROJECT_NAME} ${cpp_files})
 
 install(
-  FILES ${core_datastructures_hpp_files} 
-  DESTINATION include/${PROJECT_NAME}
+  FILES ${hpp_files} DESTINATION include/${PROJECT_NAME}
   )
 
 install(
-  TARGETS ${PROJECT_NAME}
-  DESTINATION lib/${PROJECT_NAME}
+  TARGETS ${PROJECT_NAME} DESTINATION lib/${PROJECT_NAME}
   )
     
 target_include_directories(${PROJECT_NAME} PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/../)

--- a/src/common/domain/core_datastructures/Point.cpp
+++ b/src/common/domain/core_datastructures/Point.cpp
@@ -1,3 +1,1 @@
-
-#include <Point.hpp>
 #include <core_datastructures/Point.hpp>

--- a/src/common/domain/core_datastructures/Point.hpp
+++ b/src/common/domain/core_datastructures/Point.hpp
@@ -1,5 +1,5 @@
-#ifndef POINT_HPP
-#define POINT_HPP
+#ifndef CORE_DATASTRUCTURES__POINT_HPP
+#define CORE_DATASTRUCTURES__POINT_HPP
 
 namespace core_datastructures {
     struct Point {
@@ -9,4 +9,4 @@ namespace core_datastructures {
     };
 }
 
-#endif  /*POINT_HPP*/
+#endif  /*CORE_DATASTRUCTURES__POINT_HPP*/

--- a/src/common/domain/core_datastructures/Pose.hpp
+++ b/src/common/domain/core_datastructures/Pose.hpp
@@ -1,5 +1,5 @@
-#ifndef POSE_HPP
-#define POSE_HPP
+#ifndef CORE_DATASTRUCTURES__POSE_HPP
+#define CORE_DATASTRUCTURES__POSE_HPP
 
 namespace core_datastructures {
     struct Pose {
@@ -9,4 +9,4 @@ namespace core_datastructures {
     };
 }
 
-#endif  /*POSE_HPP*/
+#endif  /*CORE_DATASTRUCTURES__POSE_HPP*/

--- a/src/common/domain/core_datastructures/Posture.hpp
+++ b/src/common/domain/core_datastructures/Posture.hpp
@@ -1,5 +1,5 @@
-#ifndef POSTURE_HPP
-#define POSTURE_HPP
+#ifndef CORE_DATASTRUCTURES__POSTURE_HPP
+#define CORE_DATASTRUCTURES__POSTURE_HPP
 
 namespace core_datastructures {
     struct Posture {
@@ -10,4 +10,4 @@ namespace core_datastructures {
     };
 }
 
-#endif  /*POSTURE_HPP*/
+#endif  /*CORE_DATASTRUCTURES__POSTURE_HPP*/

--- a/src/common/interface/package.xml
+++ b/src/common/interface/package.xml
@@ -8,12 +8,13 @@
   <license>TODO: License declaration</license>
 
   <buildtool_depend>ament_cmake</buildtool_depend>
-  
-<build_depend>rosidl_default_generators</build_depend>
 
-<exec_depend>rosidl_default_runtime</exec_depend>
+  <!-- <build_depend>common_domain</build_depend> -->
+  <build_depend>rosidl_default_generators</build_depend>
 
-<member_of_group>rosidl_interface_packages</member_of_group>
+  <exec_depend>rosidl_default_runtime</exec_depend>
+
+  <member_of_group>rosidl_interface_packages</member_of_group>
   
   <test_depend>ament_lint_auto</test_depend>
   <test_depend>ament_lint_common</test_depend>

--- a/src/modules/trajectory_generation/domain/CMakeLists.txt
+++ b/src/modules/trajectory_generation/domain/CMakeLists.txt
@@ -1,9 +1,9 @@
 cmake_minimum_required(VERSION 3.5)
 project(trajectory_generation_domain)
 
-# find_package(ament_cmake REQUIRED)
-# find_package(common_domain REQUIRED)
+find_package(ament_cmake REQUIRED)
+find_package(common_domain REQUIRED)
 
-# add_subdirectory(spline_generation)
+add_subdirectory(spline_generation)
 
-# ament_package()
+ament_package()

--- a/src/modules/trajectory_generation/domain/package.xml
+++ b/src/modules/trajectory_generation/domain/package.xml
@@ -9,6 +9,8 @@
 
   <buildtool_depend>ament_cmake</buildtool_depend>
 
+  <build_depend>common_domain</build_depend>
+  
   <test_depend>ament_lint_auto</test_depend>
   <test_depend>ament_lint_common</test_depend>
   <export>

--- a/src/modules/trajectory_generation/domain/spline_generation/CMakeLists.txt
+++ b/src/modules/trajectory_generation/domain/spline_generation/CMakeLists.txt
@@ -1,8 +1,30 @@
+cmake_minimum_required(VERSION 3.5)
+project(lib_spline_generation)
+
 file(GLOB spline_gen_cpp_files "*.cpp")
+file(GLOB spline_gen_hpp_files "*.hpp")
 
-add_library(lib_spline_generation ${spline_gen_cpp_files})
+add_library(${PROJECT_NAME} ${spline_gen_cpp_files})
 
-target_link_libraries(lib_spline_generation lib_core_datastructures)
 
-target_include_directories(lib_spline_generation PUBLIC "${CMAKE_CURRENT_SOURCE_DIR}/../")
-target_include_directories(lib_spline_generation PRIVATE "${CMAKE_SOURCE_DIR}/src/common")
+find_library(core_datastructures REQUIRED)
+find_path(core_datastructures_include_path lib_core_datastructures)
+message("core_datastructures_include_path = ${core_datastructures_include_path}")
+
+# target_link_libraries(${PROJECT_NAME} PUBLIC lib_core_datastructures)
+install(
+  FILES ${spline_gen_hpp_files} 
+  DESTINATION include/${PROJECT_NAME}
+  )
+
+install(
+  TARGETS ${PROJECT_NAME}
+  DESTINATION lib/${PROJECT_NAME}
+  )
+
+target_include_directories(
+    ${PROJECT_NAME} PUBLIC
+    
+    ${CMAKE_CURRENT_SOURCE_DIR}/../
+    ${core_datastructures_include_path}/
+)

--- a/src/modules/trajectory_generation/domain/spline_generation/CMakeLists.txt
+++ b/src/modules/trajectory_generation/domain/spline_generation/CMakeLists.txt
@@ -1,30 +1,25 @@
 cmake_minimum_required(VERSION 3.5)
-project(lib_spline_generation)
+project(spline_generation)
 
-file(GLOB spline_gen_cpp_files "*.cpp")
-file(GLOB spline_gen_hpp_files "*.hpp")
+file(GLOB cpp_files "*.cpp")
+file(GLOB hpp_files "*.hpp")
 
-add_library(${PROJECT_NAME} ${spline_gen_cpp_files})
+add_library(${PROJECT_NAME} ${cpp_files})
 
+target_link_libraries(${PROJECT_NAME} PUBLIC core_datastructures)
 
-find_library(core_datastructures REQUIRED)
-find_path(core_datastructures_include_path lib_core_datastructures)
-message("core_datastructures_include_path = ${core_datastructures_include_path}")
+# Find the path to the include directories of the core_datastructures library
+find_path(CORE_DATASTRUCTURES_INCLUDE_DIRS core_datastructures)
 
-# target_link_libraries(${PROJECT_NAME} PUBLIC lib_core_datastructures)
-install(
-  FILES ${spline_gen_hpp_files} 
-  DESTINATION include/${PROJECT_NAME}
-  )
+# Specify destination for all header files of this library
+install(FILES ${hpp_files} DESTINATION include/${PROJECT_NAME})
 
-install(
-  TARGETS ${PROJECT_NAME}
-  DESTINATION lib/${PROJECT_NAME}
-  )
+install(TARGETS ${PROJECT_NAME} DESTINATION lib/${PROJECT_NAME})
+
 
 target_include_directories(
-    ${PROJECT_NAME} PUBLIC
-    
-    ${CMAKE_CURRENT_SOURCE_DIR}/../
-    ${core_datastructures_include_path}/
+    ${PROJECT_NAME} PUBLIC 
+
+    ${CMAKE_CURRENT_SOURCE_DIR}/../ 
+    ${CORE_DATASTRUCTURES_INCLUDE_DIRS}
 )

--- a/src/modules/trajectory_generation/interface/package.xml
+++ b/src/modules/trajectory_generation/interface/package.xml
@@ -9,6 +9,8 @@
 
   <buildtool_depend>ament_cmake</buildtool_depend>
 
+  <build_depend>trajectory_generation_domain</build_depend>
+
   <test_depend>ament_lint_auto</test_depend>
   <test_depend>ament_lint_common</test_depend>
   


### PR DESCRIPTION
Fixed CMake issues. 
Modified naming conventions.
Added common_domain as a build dependency for trajectory_generation_domain. This ensures common_domain will get built first.
Provided correct include paths in trajectory_generation_domain so that it finds the common_domain header files.
To correctly build the project, go to navigation_stack->src, then do colcon build.